### PR TITLE
URL 404 Error

### DIFF
--- a/content/contribute/index.md
+++ b/content/contribute/index.md
@@ -40,7 +40,7 @@ If you want to contribute to LBRY, the first step is to understand where.
 --- | --- | ---
 | [lbry.tech](https://github.com/lbryio/lbry.tech) | JavaScript (Vue, Vuepress) | You're on it.
 | [lbry.io](https://github.com/lbryio/lbry.io) | PHP (vanilla) | A website for LBRY end-users and creators.
-| [lbry.fund](https://github.com/lbryio/lbry.fund) | HTML | A website for receiving funding from LBRY, Inc.
+| [lbry.fund](https://lbry.fund) | HTML | A website for receiving funding from LBRY, Inc.
 
 ### Auxiliary Services and Applications
 | Domain | Language (Toolset) | What Is It


### PR DESCRIPTION
https://github.com/lbryio/lbry.fund have 404 error..

to fix this problem i replace https://github.com/lbryio/lbry.fund with https://lbry.fund

![capture123456789](https://user-images.githubusercontent.com/11346292/41495609-38e4b3a4-7148-11e8-81c5-4b45680a7170.PNG)


