### PR TITLE
move adjacent header spacing to top of element

### DIFF
--- a/app/sass/pages/_page.scss
+++ b/app/sass/pages/_page.scss
@@ -63,7 +63,7 @@
     }
 
     + h2 {
-      margin-bottom: 2rem;
+      margin-top: 2rem;
     }
   }
 
@@ -77,7 +77,7 @@
     }
 
     + h3 {
-      margin-bottom: 1rem; padding-top: 0.25rem;
+      margin-top: 1rem;
     }
   }
 


### PR DESCRIPTION
I think when headers are adjacent, we want additional space at the top of the header, not the bottom. Space at the top more clearly clusters the header with it's associated text.