### PR TITLE
Removed empty href attributes

### DIFF
--- a/app/views/home.js
+++ b/app/views/home.js
@@ -70,10 +70,10 @@ module.exports = exports = () => html`
         <p>No matter your experience or skill level, <em>you</em> can progress content freedom.</p>
 
         <ul>
-          <li><a href="" title="">Coding</a></li>
-          <li><a href="" title="">Creative</a></li>
-          <li><a href="" title="">Writing</a></li>
-          <li><a href="" title="">Testing</a></li>
+          <li><a title="">Coding</a></li>
+          <li><a title="">Creative</a></li>
+          <li><a title="">Writing</a></li>
+          <li><a title="">Testing</a></li>
         </ul>
         <p>
          <a class="cta" href="/contribute">Collaborate with Contributors</a>


### PR DESCRIPTION
fixes #191 

Removed href attributes in anchor tags, thus avoiding unnecessary page refresh.