### PR TITLE
Text Select Enable - All HTML Elements

### DIFF
--- a/app/sass/_layout.scss
+++ b/app/sass/_layout.scss
@@ -1,6 +1,11 @@
 @include font-face(400);
 @include font-face(700);
-
+* {
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
+}
 html,
 body {
   width: 100%; height: 100%;


### PR DESCRIPTION
Allows text to be selected on [all HTML elements](https://www.w3schools.com/cssref/sel_all.asp), with cross-browser support.

The `*` was used because ` user-select: text;` CSS only affect text and the **select all** selector will make sure it hits all of them, making sure none are missed.

*I've not got this site set up locally to test, but for anyone that has, might be worth adding this code too for a little zest 👍 

```css
/*$lbry-teal-3 = #38d9a9 ???*/
::-moz-selection {
    color: #fff;
    background: $lbry-teal-3;
}
::selection {
    color: #fff;
    background: $lbry-teal-3;
}
```

