### PR TITLE
Add optional dependency win-node-env for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
       "app/dist"
     ]
   },
-  "version": "3.6.0"
+  "version": "3.6.0",
+  "optionalDependencies": {
+    "win-node-env": "^0.4.0"
+  }
 }


### PR DESCRIPTION
Fixes #235

Added optional dependency [win-node-env](https://github.com/laggingreflex/win-node-env) for Windows to be able to run npm scripts that set (common) environment variables. It won't install on any other OS than Windows.
Reference: https://github.com/laggingreflex/win-node-env