### PR TITLE
Revert "Add optional dependency win-node-env for Windows"

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,9 +78,6 @@
   },
   "main": "server.js",
   "name": "lbry.tech",
-  "optionalDependencies": {
-    "win-node-env": "^0.4.0"
-  },
   "private": true,
   "scripts": {
     "css": "sass --load-path=node_modules --update app/sass:app/dist --style compressed",


### PR DESCRIPTION
Reverts lbryio/lbry.tech#241

Issues updating Yarn lockfile and preventing Heroku build from passing.