### PR TITLE
fix: 0.37 SDK support

### DIFF
--- a/app/components/client/playground-scripts.js
+++ b/app/components/client/playground-scripts.js
@@ -170,7 +170,7 @@ function fetchMetadata(exampleNumber, data) {
       send({
         claim: data,
         message: "fetch metadata",
-        method: "claim_tip",
+        method: "support_create",
         example: exampleNumber
       });
 
@@ -193,7 +193,7 @@ function getMemeInfo() { // TODO: Error handling
     language: document.getElementById("meme-language").value,
     license: document.getElementById("meme-license").value,
     name: document.getElementById("meme-title").value,
-    nsfw: document.getElementById("meme-nsfw-flag").checked,
+    tags: document.getElementById("meme-nsfw-flag").checked ? "mature" : "[]",
     title: document.getElementById("meme-title").value
   };
 }
@@ -216,7 +216,7 @@ function initializePlayground() {
 function playgroundResponseForExample1(source) {
   return `
     <pre><code class="language-bash"><span class="token comment"># With the LBRY app/daemon running locally, you can use this in your Terminal</span>
-curl --header <span class="token string">"Content-Type: application/json"</span> --data <span class="token string">'{ "method": "resolve", "params": { "uri": "${source}" }}'</span> <span class="token url">http://localhost:5279    </span>
+curl --header <span class="token string">"Content-Type: application/json"</span> --data <span class="token string">'{ "method": "resolve", "params": { "urls": "${source}" }}'</span> <span class="token url">http://localhost:5279    </span>
 </code></pre>
 
     <div class="loader" id="temp-loader"></div>
@@ -227,7 +227,7 @@ curl --header <span class="token string">"Content-Type: application/json"</span>
 function playgroundResponseForExample2(source) {
   return `
     <pre><code class="language-bash"><span class="token comment"># With the LBRY app/daemon running locally, you can use this in your Terminal</span>
-curl --header <span class="token string">"Content-Type: application/json"</span> --data <span class="token string">'{ "method": "publish", "params": { "name": "${source.name}", "file_path": "ABSOLUTE_PATH_TO_MEDIA_ON_YOUR_COMPUTER", "bid": "0.001", "metadata": { "description": "${source.description}", "title": "${source.title}", "language": "${source.language}", "license": "${source.license}", "nsfw": ${source.nsfw} }}}'</span> <span class="token url">http://localhost:5279    </span>
+curl --header <span class="token string">"Content-Type: application/json"</span> --data <span class="token string">'{ "method": "publish", "params": { "name": "${source.name}", "file_path": "ABSOLUTE_PATH_TO_MEDIA_ON_YOUR_COMPUTER", "bid": "0.001", "metadata": { "description": "${source.description}", "title": "${source.title}", "languages": "${source.language}", "license": "${source.license}", "tags": ${source.tags} }}}'</span> <span class="token url">http://localhost:5279    </span>
 </code></pre>
 
     <div class="loader" id="temp-loader"></div>
@@ -240,7 +240,7 @@ function playgroundResponseForExample3(source) {
 
   return `
     <pre><code class="language-bash"><span class="token comment"># With the LBRY app/daemon running locally, you can use this in your Terminal</span>
-curl --header <span class="token string">"Content-Type: application/json"</span> --data <span class="token string">'{ "method": "claim_tip", "params": { "amount": "0.001", "claim_id": "${source}" }}'</span> <span class="token url">http://localhost:5279    </span>
+curl --header <span class="token string">"Content-Type: application/json"</span> --data <span class="token string">'{ "method": "support_create", "params": { "amount": "0.001", "claim_id": "${source}", "--tip" }}'</span> <span class="token url">http://localhost:5279    </span>
 </code></pre>
 
     <div class="loader" id="temp-loader"></div>

--- a/app/helpers/fetch-metadata.js
+++ b/app/helpers/fetch-metadata.js
@@ -18,7 +18,7 @@ import { send } from "~socket";
 import uploadImage from "./upload-image";
 
 const allowedQueryMethods = [
-  "claim_tip",
+  "support_create",
   "publish",
   "resolve"
 ];
@@ -79,7 +79,7 @@ export default async(data, socket) => {
   switch(true) {
     //  T I P
     //  E X A M P L E
-    case resolveMethod === "claim_tip":
+    case resolveMethod === "support_create":
       if (!approvedContentIdsForTipping.includes(claimAddress)) {
         return send(socket, {
           example: data.example,
@@ -95,6 +95,7 @@ export default async(data, socket) => {
       apiRequestMethod = "POST";
       body.amount = "0.001"; // Hardcoded tip amount
       body.claim_id = claimAddress;
+      body.tip = true;
 
       break;
 
@@ -109,11 +110,11 @@ export default async(data, socket) => {
       body.author = "lbry.tech";
       body.bid = "0.001"; // Hardcoded publish amount
       body.description = dataDetails.description;
-      body.language = dataDetails.language;
+      body.languages = [dataDetails.language];
       body.license = dataDetails.license;
       body.name = dataDetails.name + "-" + randomString(10);
-      body.nsfw = dataDetails.nsfw;
       body.title = dataDetails.title;
+      body.tags = dataDetails.tags;
 
       // Gotta let the blockchain know what to save
       body.file_path = dataDetails.file_path;
@@ -128,7 +129,7 @@ export default async(data, socket) => {
           switch(true) {
             case data.example === 2:
             case memePublishResponse.result:
-            case memePublishResponse.result.claim_address:
+            case memePublishResponse.result.outputs[0].address:
               explorerNotice = memePublishMessaging(memePublishResponse);
               break;
 
@@ -280,11 +281,11 @@ function memePublishMessaging(source) {
 
       <br/><br/>
 
-      To see Proof of Work (lol) that your meme is on the LBRY blockchain, <a href="https://explorer.lbry.com/tx/${source.result.output.txid}?address=${source.result.claim_address}" rel="noopener noreferrer" target="_blank" title="Your meme, on our blockchain explorer">check it out</a> on our blockchain explorer! Please note that it may take a couple minutes for the transaction to be confirmed.
+      To see Proof of Work (lol) that your meme is on the LBRY blockchain, <a href="https://explorer.lbry.com/tx/${source.result.outputs[0].txid}?address=${source.result.outputs[0].address}" rel="noopener noreferrer" target="_blank" title="Your meme, on our blockchain explorer">check it out</a> on our blockchain explorer! Please note that it may take a couple minutes for the transaction to be confirmed.
 
       <br/><br/>
 
-      You can also check out your meme (once the transaction is confirmed) on <a href="https://open.lbry.com/${source.result.lbrytech_claim_name}#${source.result.claim_id}" rel="noopener noreferrer" target="_blank" title="Your meme, on LBRY">LBRY</a> or <a href="https://spee.ch/${source.result.claim_id}/${source.result.lbrytech_claim_name}" rel="noopener noreferrer" target="_blank" title="Your meme, on spee.ch">Spee.ch</a>!
+      You can also check out your meme (once the transaction is confirmed) on <a href="https://open.lbry.com/${source.result.lbrytech_claim_name}#${source.result.outputs[0].claim_id}" rel="noopener noreferrer" target="_blank" title="Your meme, on LBRY">LBRY</a> or <a href="https://spee.ch/${source.result.outputs[0].claim_id}/${source.result.lbrytech_claim_name}" rel="noopener noreferrer" target="_blank" title="Your meme, on spee.ch">Spee.ch</a>!
     </p>
 
     <br/>
@@ -294,8 +295,7 @@ function memePublishMessaging(source) {
 function tipCompletionMessaging(source) {
   return `
     <p class="playground__description success">
-      If you want proof of the tip you just gave on behalf of LBRY, <a href="https://explorer.lbry.com/tx/${source.result.txid}" rel="noopener noreferrer" target="_blank" title="Your tip, on our blockchain explorer">check it out</a> on our blockchain explorer! Please note that it may take a couple minutes for the transaction to be confirmed.
+      If you want proof of the tip you just gave on behalf of LBRY, <a href="https://explorer.lbry.com/tx/${source.result.outputs[0].txid}" rel="noopener noreferrer" target="_blank" title="Your tip, on our blockchain explorer">check it out</a> on our blockchain explorer! Please note that it may take a couple minutes for the transaction to be confirmed.
     </p><br/>
   `;
 }
-

--- a/app/sockets.js
+++ b/app/sockets.js
@@ -123,11 +123,11 @@ function generateContent(exampleNumber, displayTrendingContent) {
                   class="media__thumb"
                   data-action="choose claim"
                   data-claim-id="${part.name}"
-                  ${part.value.stream.metadata.thumbnail.length ? `style="background-image: url(${makeImageSourceSecure(part.value.stream.metadata.thumbnail)})"` : ""}
+                  ${part.value.thumbnail.url.length ? `style="background-image: url(${makeImageSourceSecure(part.value.thumbnail.url)})"` : ""}
                 ></figure>
 
                 <div class="media__title">
-                  ${part.value.stream.metadata.title}
+                  ${part.value.title}
                 </div>
 
                 <div class="media__subtitle">
@@ -169,14 +169,14 @@ function generateContent(exampleNumber, displayTrendingContent) {
     const renderedContentCollection = [];
 
     for (const url of approvedUrls)
-      rawContentCollection.push(fetchMetadata({ claim: url, method: "resolve", example: exampleNumber }));
+      rawContentCollection.push(fetchMetadata({ claim: url, method: "resolve", example: 1 }));
 
     return Promise.all(rawContentCollection).then(collection => {
       for (const part of collection) {
         if (
           part &&
           part.value &&
-          part.value.stream.metadata.thumbnail &&
+          part.value.thumbnail.url &&
           part.channel_name
         ) {
           renderedContentCollection.push(`
@@ -186,11 +186,11 @@ function generateContent(exampleNumber, displayTrendingContent) {
                 data-action="choose claim"
                 data-claim-id="${part.claim_id}"
                 data-name=${part.name}
-                style="background-image: url(${makeImageSourceSecure(part.value.stream.metadata.thumbnail)})">
+                style="background-image: url(${makeImageSourceSecure(part.value.thumbnail.url)})">
               </figure>
 
               <div class="media__title">
-                ${part.value.stream.metadata.title}
+                ${part.value.title}
               </div>
 
               <div class="media__subtitle">

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
     "@inc/fastify-ws": "^1.1.0",
-    "@octokit/rest": "^16.25.4",
+    "@octokit/rest": "^16.26.0",
     "@slack/client": "^5.0.1",
-    "async": "^2.6.2",
-    "async-es": "^2.6.2",
+    "async": "^3.0.0",
+    "async-es": "^3.0.0",
     "choo": "^6.13.3",
     "choo-async": "^0.1.1",
     "choo-devtools": "^2.5.1",


### PR DESCRIPTION
Basic support for the new SDK. Tested locally.

Not sure how ```rawContentCollection.push(fetchMetadata({ claim: url, method: "resolve", example: 1 }));``` worked with example = 3...it would not work locally (would show a blank list on tip page). Maybe there's a better fix for it, that's the best I had for now. 