### PR TITLE
Update twitter link

### DIFF
--- a/app/components/feature-links.js
+++ b/app/components/feature-links.js
@@ -31,7 +31,7 @@ const links = [
   //     title: "Join Our Team"
   //   },
   {
-    href: "https://twitter.com/lbryio",
+    href: "https://twitter.com/LBRYcom",
     image: "https://spee.ch/9c38db124b85736adbcca48cdf34877d2110bbcd/GeoShapes.png",
     title: "Twitter"
   },


### PR DESCRIPTION
I believe the current Twitter link on https://lbry.tech/community is outdated. This should fix it.

Just so you know, there's also another error on the page, which is not fixed in this PR.

> And don't forget to sign up for developer-only mailing list, below.

But the mailing list is not on the page.