### PR TITLE
Update(fix) wallet-server.md

### DIFF
--- a/documents/resources/wallet-server.md
+++ b/documents/resources/wallet-server.md
@@ -8,7 +8,7 @@ This guide will walk you through the process of setting up a LBRY hub server. Th
 
 
 ## Start With A Fresh Server
-Hardware requirements vary between versions. Having following hardware should let you get started. For best perfomance use 32 GB of RAM. But recommended values should be enough for few clients.
+Hardware requirements vary between versions. Having following hardware and a fresh Ubuntu 18.04 install should let you get started. For best perfomance use 32 GB of RAM. But recommended values should be enough for few clients.
 ##### For latest version 17.3.3
 - 4-core CPU
 - 22 GB RAM

--- a/documents/resources/wallet-server.md
+++ b/documents/resources/wallet-server.md
@@ -9,11 +9,11 @@ This guide will walk you through the process of setting up a LBRY hub server. Th
 
 ## Start With A Fresh Server
 Hardware requirements vary between versions. Having following hardware and a fresh Ubuntu 18.04 install should let you get started. For best perfomance use 32 GB of RAM. But recommended values should be enough for few clients.
-##### For latest version 17.3.3
+##### For latest version v0.17.3.3
 - 4-core CPU
 - 22 GB RAM
 - 320 GB Storage
-##### For pre-release 17.4.6
+##### For pre-release v0.17.4.6
 - 4-core CPU
 - 16 GB RAM (Possible to get running under 10 GB following this guide, but more is strongly recommended and possible necessary as LBRY grows)
 - 320 GB Storage(SSD) (At the end of 2021 the storage used by whole hub-server is around 273 GB, of which 145 GB is used by lbrycrd)
@@ -23,9 +23,9 @@ Make sure your firewall has ports 9246 and 50001 open. 9246 is the port lbrycrd 
 ## Install lbrycrd
 
 ### Download and setup
-Download the version of yout choice:  
-[latest release of lbrycrd 17.3.3](https://github.com/lbryio/lbrycrd/releases/latest).  
-[pre-release of lbrycrd 17.4.6](https://github.com/lbryio/lbrycrd/releases/tag/v0.17.4.6) (Check the additional info from the release page)
+Download the version of your choice:  
+[latest release of lbrycrd v0.17.3.3](https://github.com/lbryio/lbrycrd/releases/latest)  
+[pre-release of lbrycrd v0.17.4.6](https://github.com/lbryio/lbrycrd/releases/tag/v0.17.4.6) (Check the additional info from the release page)
 
 Extract the .zip to the directory of your choice(in this guide we use `/home/$USER`). Then, create a folder on your home directory called `.lbrycrd` and save the following to `.lbrycrd/lbrycrd.conf`:
 ```


### PR DESCRIPTION
Updated HW requirements, I don't think it was possible to get hub-server running at all on the old values. New values used contain some amount of guessing.

The current steps left room for a lot of guessing of what exactly to do.(Like when to exactly start lbrycrdd, or the info that it doesn't matter when different things are started/stopped) This wasn't completely obvious for me. I added bit more details to the guide, which hopefully makes it easier to get hub running for people.

As version 17.4.6 requires much less RAM, I added it to the guide. I don't know if there are other things than RAM, for people to care, when they choose the version to use. Probably could use some piece of text for how to choose?

Updated word "wallet server" to "hub server" when referring to whole thing.

Experience with old guide:
It took me ~8 days total to get hub-server running, mainly because lbrycrd crashing for lack of RAM(had 16GB) and there was no info about blockchain snapshot on this guide(I synced from start and did --reindex after crashes instead, this took most of the time).     

After needing to ask help and trying with 17.4.6, it took me ~2 days to get everything running. And that was when letting lbrycrd fully sync(from snapshot) before starting docker stuff( I didn't want more unexpected crashes that make lbrycrd want --reindex). In the end, on 17.4.6 it was very straight-forward to get things going.  (Luckily I had 315GB of storage on server, instead of 200GB as in guide) Currently it's using 8.7 GB of RAM, with this `ES_JAVA_OPTS=-Xms2g -Xmx2g`. Forgot it on lower value from earlier tries if that matters 

EDIT:
Yesterday .lbrycrd took 145GB (value mentioned in guide for what to expect the lbrycrd needing)
Now it takes 139GB
There has been reboot between those `du -sh .lbrycrd` commands. Don't think I have touched anything in .lbrycrd manually.