### PR TITLE
wallet-server: update suggested systemd unit

### DIFF
--- a/documents/resources/wallet-server.md
+++ b/documents/resources/wallet-server.md
@@ -40,7 +40,9 @@ Description="LBRYcrd daemon"
 After=network.target
 
 [Service]
-ExecStart=/home/<your_user>/lbrycrdd -datadir="/home/<your_user>/.lbrycrd"
+ExecStart=/home/<your_user>/lbrycrdd -datadir="/home/<your_user>/.lbrycrd" -pid="/home/<your_user>/pid"
+Type=Forking
+PIDFile=/home/<your_user>/.lbrycrd/pid
 User=<your_user>
 Group=<your_user_group>
 Restart=on-failure


### PR DESCRIPTION
Use `Type=Forking`. By default, `Type=Simple` is used and it expects that the daemon stays forking in the foreground. However, lbrycrdd does the opposite and forks/goes to background. This confuses systemd a little bit:

```
Dec 09 10:30:28 lbry.devass.club systemd[1]: lbrycrdd.service: Unit process 12237 (lbrycrdd) remains running after unit stopped.
```

So basically it thinks that the unit stops working instantly. When the correct type is used, systemd should be able to handle this situations, along with restarts, properly.

See also: [AUR systemd service](https://aur.archlinux.org/cgit/aur.git/tree/lbrycrd.service?h=lbrycrd)

Reopening https://github.com/lbryio/lbry.tech/pull/368

> it should only fork if you use the -daemon flag or if you have daemon in your config file

This is not the case

> @derlaft how are you running lbrycrdd?

Exactly as in documentation: `ExecStart=/home/user/lbrycrdd -datadir="/home/user/.lbrycrd"`